### PR TITLE
build: make --without-{python,perl,r} actually disable the language

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -766,17 +766,28 @@ def _compile_java_plugins_in_folder(env, folder):
         )
 
 
+_LANGUAGE_SOURCE_BY_OPTION = {
+    "without-python": "Py.cxx",
+    "without-perl": "Perl.cxx",
+    "without-r": "R.cxx",
+}
+
+
 def build_language_objects(env):
-    """Build language support objects and return the language file list."""
-    languages = Glob("src/languages/*.cxx")
+    """Build language support objects, skipping any disabled languages."""
+    disabled = {
+        src for opt, src in _LANGUAGE_SOURCE_BY_OPTION.items() if GetOption(opt)
+    }
+    languages = [
+        node for node in Glob("src/languages/*.cxx")
+        if os.path.basename(node.get_path()) not in disabled
+    ]
 
     for language in languages:
         output = language.get_path().replace("src", "obj").replace(".cxx", ".os")
         _build_language_object(env, language, output)
 
     return languages
-
-    env.Program("PluGen/plugen", Glob("src/PluGen/*.cxx"), CPPPATH=[Dir("src")])
 
 def _build_language_object(env, language, output):
     """Build a single language object file."""
@@ -787,11 +798,14 @@ def _build_language_object(env, language, output):
 
 
 def build_main_executable(env, languages):
-    """Build the main PluMA executable."""
-    program_libs = [
-        "pthread", "m", "dl", "crypt", "c",
-        f"python{python_version}", "util", "perl", "R", "RInside",
-    ]
+    """Build the main PluMA executable, linking only enabled language runtimes."""
+    program_libs = ["pthread", "m", "dl", "crypt", "c"]
+    if not GetOption("without-python"):
+        program_libs.extend([f"python{python_version}", "util"])
+    if not GetOption("without-perl"):
+        program_libs.append("perl")
+    if not GetOption("without-r"):
+        program_libs.extend(["R", "RInside"])
 
     env.Append(LIBPATH=[LibPath("")])
     env.Program(

--- a/src/PluginManager.h
+++ b/src/PluginManager.h
@@ -46,10 +46,18 @@
 #include <fstream>
 
 #include "languages/Compiled.h"
+#ifdef HAVE_PYTHON
 #include "languages/Py.h"
+#endif
+#ifdef HAVE_R
 #include "languages/R.h"
+#endif
+#ifdef HAVE_PERL
 #include "languages/Perl.h"
+#endif
+#ifdef HAVE_JAVA
 #include "languages/Java.h"
+#endif
 #ifdef HAVE_RUST
 #include "languages/Rust.h"
 #endif
@@ -122,9 +130,15 @@ public:
 #else
         supported.push_back(new Compiled("C", "so", pluginpath, "lib"));
 #endif
+#ifdef HAVE_PYTHON
         supported.push_back(new Py("Python", "py", pluginpath));
+#endif
+#ifdef HAVE_R
         supported.push_back(new MiAMi::R("R", "R", pluginpath, argc, argv));
+#endif
+#ifdef HAVE_PERL
         supported.push_back(new Perl("Perl", "pl", pluginpath));
+#endif
 #ifdef HAVE_JAVA
         supported.push_back(new Java("Java", "class", pluginpath));
 #endif


### PR DESCRIPTION
## Summary

After PR #7 (SConstruct cleanup), the per-language `--without-*` flags only gated the SWIG wrapper invocation. The rest of the build was still unconditional, so e.g. `--without-r` would still:

- Compile `src/languages/R.cxx` into pluma (the `*.cxx` glob in `build_language_objects` was unfiltered)
- Link pluma against `-lR -lRInside` (hard-coded in `program_libs`)
- Require `PluginManager.h` to include `languages/R.h` and push a `MiAMi::R` instance into `supportedLanguages`

This PR finishes the gating so `--without-{python,perl,r}` actually produces a binary that does not require the corresponding runtime at link or load time.

## Changes

- **SConstruct**:
  - \`build_language_objects\` filters the \`src/languages/*.cxx\` glob by a small \`option → filename\` map, so adding new gated languages is a one-liner.
  - \`build_main_executable\` composes \`program_libs\` conditionally based on which \`--without-*\` flags are set, instead of always emitting the full list.
- **PluginManager.h**: wraps the language \`#include\` and \`supported.push_back\` calls in \`#ifdef HAVE_PYTHON / HAVE_R / HAVE_PERL\`, matching the existing \`HAVE_JAVA\` / \`HAVE_RUST\` pattern. \`configure_python / configure_perl / configure_r\` already set these defines only when the language is enabled, so no further SConstruct change is needed.

## Scope notes

- Java is **not** gated here — \`--without-java\` is not declared in \`OPTIONS\` yet. That's part of #13.
- The original branch carried two other commits (Java/Python detection bugfixes, and a \`-flto\` strip for perl ldopts) which are now either superseded by upstream master or already covered by #13. The branch was reworked to a single clean commit on top of \`master\`.

## Test plan

- [ ] \`scons --without-r\` produces a \`pluma\` binary that doesn't require libR/libRInside at link time
- [ ] \`scons --without-python\` produces a binary that doesn't require libpython
- [ ] \`scons --without-perl\` produces a binary that doesn't require libperl
- [ ] \`scons\` (default, all enabled) still produces the same binary as before